### PR TITLE
Introduce Auto Reorder Setting Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Examples:
 
 ![](https://i.imgur.com/fEyG45b.png)
 
+Settings: 
+
+- Toggle "Auto Reorder" setting in settings tab to allow plugin to automatically reorder checklists when file is modified.
+
 **More Infos**
 
 [Github repository](https://github.com/Erl-koenig/obsidian-checkboxReorder)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,33 @@
 import { Plugin, MarkdownView, Editor } from "obsidian";
+import {CheckboxReorderPluginSettingTab} from './settings'
 import { reorderCheckboxesInFile } from "src/reorderCheckboxes";
 
+interface CheckboxReorderPluginSettings {
+	autoReorder: boolean;
+}
+
+const DEFAULT_SETTINGS: Partial<CheckboxReorderPluginSettings> = {
+	autoReorder: false
+}
+
 export default class CheckboxReorderPlugin extends Plugin {
+	settings: CheckboxReorderPluginSettings;
+
 	async onload() {
+		await this.loadSettings();
+
 		console.log("Checkbox Reorder Plugin loaded");
+		
+
+		this.addSettingTab(new CheckboxReorderPluginSettingTab(this.app, this))
+
+		if(this.settings.autoReorder){
+			this.registerEvent(this.app.vault.on("modify", () => {
+				const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+
+				this.reorderCheckboxes(view?.editor);
+			}))
+		}
 
 		this.addCommand({
 			id: "reorder-checkboxes",
@@ -12,6 +36,14 @@ export default class CheckboxReorderPlugin extends Plugin {
 				this.reorderCheckboxes(editor);
 			},
 		});
+	}
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
 	}
 
 	reorderCheckboxes(editor: Editor) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,13 +21,12 @@ export default class CheckboxReorderPlugin extends Plugin {
 
 		this.addSettingTab(new CheckboxReorderPluginSettingTab(this.app, this))
 
-		if(this.settings.autoReorder){
-			this.registerEvent(this.app.vault.on("modify", () => {
+		this.registerEvent(this.app.vault.on("modify", () => {
+			if(this.settings.autoReorder){
 				const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-
-				this.reorderCheckboxes(view?.editor);
-			}))
-		}
+				view?.editor && this.reorderCheckboxes(view?.editor);
+			}
+		}))
 
 		this.addCommand({
 			id: "reorder-checkboxes",

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,9 +22,14 @@ export default class CheckboxReorderPlugin extends Plugin {
 		this.addSettingTab(new CheckboxReorderPluginSettingTab(this.app, this))
 
 		this.registerEvent(this.app.vault.on("modify", () => {
+			
 			if(this.settings.autoReorder){
 				const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-				view?.editor && this.reorderCheckboxes(view?.editor);
+				const cursorPosition = view?.editor.getCursor()
+				if(view?.editor && cursorPosition){
+					this.reorderCheckboxes(view?.editor);
+					view?.editor.setCursor(cursorPosition);
+				}
 			}
 		}))
 
@@ -43,6 +48,7 @@ export default class CheckboxReorderPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+		this.reorderCheckboxes(this.app.workspace.getActiveViewOfType(MarkdownView)?.editor)
 	}
 
 	reorderCheckboxes(editor: Editor) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,30 @@
+import CheckboxReorderPlugin from './main'
+import { App, PluginSettingTab, Setting } from 'obsidian'
+
+export class CheckboxReorderPluginSettingTab extends PluginSettingTab{
+	plugin: CheckboxReorderPlugin 
+
+	constructor(app: App, plugin: CheckboxReorderPlugin) {
+		super(app, plugin); 
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const {containerEl} = this;
+
+		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName('Auto Reorder')
+			.setDesc('If toggled, checkboxes will be automatically reordered when checked.')
+			.addToggle((toggle) => 
+				toggle
+					.setValue(false)
+					.setValue(this.plugin.settings.autoReorder)
+					.onChange(async (value) => {
+						this.plugin.settings.autoReorder = value;
+						await this.plugin.saveSettings();
+					})
+					)
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,8 +15,8 @@ export class CheckboxReorderPluginSettingTab extends PluginSettingTab{
 		containerEl.empty();
 
 		new Setting(containerEl)
-			.setName('Auto Reorder')
-			.setDesc('If toggled, checkboxes will be automatically reordered when checked.')
+			.setName("Auto Reorder")
+			.setDesc("If toggled, checkboxes will be automatically reordered when checked.")
 			.addToggle((toggle) => 
 				toggle
 					.setValue(false)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,10 +16,9 @@ export class CheckboxReorderPluginSettingTab extends PluginSettingTab{
 
 		new Setting(containerEl)
 			.setName("Auto Reorder")
-			.setDesc("If toggled, checkboxes will be automatically reordered when checked.")
+			.setDesc("If toggled, checkboxes will be reordered when file is modified.")
 			.addToggle((toggle) => 
 				toggle
-					.setValue(false)
 					.setValue(this.plugin.settings.autoReorder)
 					.onChange(async (value) => {
 						this.plugin.settings.autoReorder = value;


### PR DESCRIPTION
# #6 
This PR will solve issue #6 and introduce new settings tab feature called "Auto Reorder."

### Major changes

- New settings.ts file was created to contain any new setting tab features 
- Auto Reorder tab was added to plugin settings tab
    - Auto Reorder Setting tab has toggle slider which will turn Auto Reorder on and off
- New event was registered for autoReorder feature. 
    - This event will fire any time the current file is modified and check if Auto Reorder setting is toggled. If toggled, the reorderCheckboxes function will run without command needing to be entered into command line. 

### Documentation changes

- README.md was updated to detail Auto Reorder feature for users

### Implementation/Testing
1. Build plugin and install to current Vault. 
2. Navigate to Settings > Community plugins > Checkbox Reorder and toggle "Auto Reorder"
3. Create checklist in any md file.
4. Check any box within the checklist and see it automatically be reordered to bottom of list.