### PR TITLE
Support for -[/] half-checked checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This plugin reorders completed checkboxes to the end of the according list.
 -   Press CTRL + P (cmd + P on mac) and run "Reorder checkboxes"
 -   For convenience, use a keyboard shortcut to bind the command
 
+## Fork changes:
+added support for -[/] annotaded half-checked checkboxes (their functionality is provided by differente plugins). They are always placed in the middle between checked and unchecked. 
+
 Examples:
 
 ![](https://i.imgur.com/fEyG45b.png)

--- a/src/reorderCheckboxes.ts
+++ b/src/reorderCheckboxes.ts
@@ -1,10 +1,13 @@
 function reorderCheckboxesInList(inputText: string, moveUp: boolean) {
-	const checkboxPattern = /^- \[(x| )\] .+(\n[ \t]+-.*)*$/gm;
+	const checkboxPattern = /^- \[(x| |\/)\] .+(\n[ \t]+-.*)*$/gm;
 
 	const allCheckboxes = inputText.match(checkboxPattern) ?? [];
 
 	const uncheckedCheckboxes = allCheckboxes.filter((cb) =>
 		cb.startsWith("- [ ]"),
+	);
+	const halfCheckedCheckboxes = allCheckboxes.filter(
+		(cb) => cb.startsWith("- [/]")
 	);
 	const checkedCheckboxes = allCheckboxes.filter((cb) =>
 		cb.startsWith("- [x]"),
@@ -12,9 +15,9 @@ function reorderCheckboxesInList(inputText: string, moveUp: boolean) {
 
 	let reorderedCheckboxes: string[];
 	if (moveUp) {
-		reorderedCheckboxes = [...uncheckedCheckboxes, ...checkedCheckboxes];
+		reorderedCheckboxes = [...uncheckedCheckboxes, ...halfCheckedCheckboxes, ...checkedCheckboxes];
 	} else {
-		reorderedCheckboxes = [...checkedCheckboxes, ...uncheckedCheckboxes];
+		reorderedCheckboxes = [...checkedCheckboxes, ...halfCheckedCheckboxes, ...uncheckedCheckboxes];
 	}
 
 	const reorderedText = inputText.replace(
@@ -26,7 +29,7 @@ function reorderCheckboxesInList(inputText: string, moveUp: boolean) {
 }
 
 export function reorderCheckboxesInFile(inputText: string, moveUp: boolean) {
-	const checkboxListPattern = /^- .+(\n[ \t]*- .*)*$/gm;
+	const checkboxListPattern = /^- \[.+(\n[ \t]*- .*)*$/gm;
 	const reorderedText = inputText.replace(checkboxListPattern, (match) =>
 		reorderCheckboxesInList(match, moveUp),
 	);


### PR DESCRIPTION
Added support for `-[/]` checkboxes. This is very useful when using a plugin for half-checked boxes (for example https://github.com/KubaMiszcz/MultiStateCheckBoxSwitcher).  